### PR TITLE
Add support for retrieving advanced thermostat settings

### DIFF
--- a/infinitive.go
+++ b/infinitive.go
@@ -68,6 +68,26 @@ func getConfig() (*TStatZoneConfig, bool) {
 	}, true
 }
 
+func getTstatSettings() (*TStatSettings, bool) {
+	tss := TStatSettings{}
+	ok := infinity.ReadTable(devTSTAT, &tss)
+	if !ok {
+		return nil, false
+	}
+
+	return &TStatSettings{
+		BacklightSetting: tss.BacklightSetting,
+		AutoMode:         tss.AutoMode,
+		DeadBand:         tss.DeadBand,
+		CyclesPerHour:    tss.CyclesPerHour,
+		SchedulePeriods:  tss.SchedulePeriods,
+		ProgramsEnabled:  tss.ProgramsEnabled,
+		TempUnits:        tss.TempUnits,
+		DealerName:       tss.DealerName,
+		DealerPhone:      tss.DealerPhone,
+	}, true
+}
+
 func getAirHandler() (AirHandler, bool) {
 	b := cache.get("blower")
 	tb, ok := b.(*AirHandler)

--- a/tables.go
+++ b/tables.go
@@ -171,3 +171,21 @@ func (params *TStatVacationParams) fromAPI(config *APIVacationConfig) byte {
 
 	return flags
 }
+
+type TStatSettings struct {
+	BacklightSetting uint8
+	AutoMode         uint8
+	Unknown1         uint8
+	DeadBand         uint8
+	CyclesPerHour    uint8
+	SchedulePeriods  uint8
+	ProgramsEnabled  uint8
+	TempUnits        uint8
+	Unknown2         uint8
+	DealerName       [20]byte
+	DealerPhone      [20]byte
+}
+
+func (params TStatSettings) addr() InfinityTableAddr {
+	return InfinityTableAddr{0x00, 0x3B, 0x06}
+}

--- a/webserver.go
+++ b/webserver.go
@@ -26,6 +26,14 @@ func webserver(port int) {
 	r.Use(handleErrors) // attach error handling middleware
 
 	api := r.Group("/api")
+
+	api.GET("/tstat/settings", func(c *gin.Context) {
+		tss, ok := getTstatSettings()
+		if ok {
+			c.JSON(200, tss)
+		}
+	})
+
 	api.GET("/zone/1/config", func(c *gin.Context) {
 		cfg, ok := getConfig()
 		if ok {


### PR DESCRIPTION
This extends the API to allow retrieving from table 003b06 in the thermostat. Available values include the deadband spread and the selected temperature display units, among other things as noted [here](http://cocoontech.com/forums/topic/11372-carrier-infinity/page-10#entry204765).